### PR TITLE
[FE] 메인페이지 / 상세페이지 데이터 페칭 등

### DIFF
--- a/client/src/common/constants/sort.ts
+++ b/client/src/common/constants/sort.ts
@@ -13,6 +13,34 @@ export const CATEGORIES = {
   etc: [11, '기타'],
 } as const;
 
+export type CategoryNumber = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
+export type CategoryValue =
+  | '테크/가전'
+  | '패션/잡화'
+  | '홈/리빙'
+  | '뷰티'
+  | '푸드'
+  | '스포츠'
+  | '컬쳐'
+  | '캐릭터/굿즈'
+  | '반려동물'
+  | '게임/취미'
+  | '기타';
+
+export const CATEGORY_NUMBER_TO_KO: Record<CategoryNumber, CategoryValue> = {
+  1: '테크/가전',
+  2: '패션/잡화',
+  3: '홈/리빙',
+  4: '뷰티',
+  5: '푸드',
+  6: '스포츠',
+  7: '컬쳐',
+  8: '캐릭터/굿즈',
+  9: '반려동물',
+  10: '게임/취미',
+  11: '기타',
+};
+
 export const ORDERS = {
   recent: '최신순',
   popular: '인기순',

--- a/client/src/common/types/responseTypes.ts
+++ b/client/src/common/types/responseTypes.ts
@@ -12,3 +12,5 @@ export type Project = {
 };
 
 export type Projects = Project[];
+
+export type ProjectDetail = Project & { categoryId: number };

--- a/client/src/common/utils/formatting.ts
+++ b/client/src/common/utils/formatting.ts
@@ -17,3 +17,11 @@ export const calculateAchievementRate = (targetAmount: number, currentAmount: nu
   const achievementRate = (currentAmount / targetAmount) * 100;
   return achievementRate > 1 ? achievementRate : 1;
 };
+
+export const dateToString = (date = new Date()) => {
+  const year: number = date.getFullYear();
+  const month: string = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day: string = date.getDate().toString().padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+};

--- a/client/src/common/utils/index.ts
+++ b/client/src/common/utils/index.ts
@@ -1,3 +1,9 @@
 export { imageCompressor } from './imageCompressor';
-export { combineClassNames, dday, formattingNumber, calculateAchievementRate } from './formatting';
+export {
+  combineClassNames,
+  dday,
+  formattingNumber,
+  calculateAchievementRate,
+  dateToString,
+} from './formatting';
 export { handleImageError } from './handleImageError';

--- a/client/src/components/editor/TuiEditor.tsx
+++ b/client/src/components/editor/TuiEditor.tsx
@@ -7,12 +7,7 @@ type Props = {
   imageHandler: (blob: File, callback: typeof Function) => void;
 };
 
-const toolbar = [
-  ['heading', 'bold', 'italic', 'strike'],
-  ['hr', 'quote'],
-  ['ul', 'ol', 'task', 'indent', 'outdent'],
-  ['image', 'link'],
-];
+const toolbar = [['heading', 'bold', 'italic', 'strike'], ['hr', 'quote', 'ul', 'ol'], ['image']];
 
 function TuiEditor({ content, editorRef, imageHandler }: Props) {
   return (

--- a/client/src/components/project/ProjectDetail.tsx
+++ b/client/src/components/project/ProjectDetail.tsx
@@ -10,7 +10,8 @@ function ProjectDetail() {
   if (isLoading) return <div>Loading....</div>;
 
   return (
-    <div className='w-[54%]'>
+    // <div className='w-[54%]'>
+    <div>
       <h2 className='text-2xl font-bold mb-40pxr'>프로젝트 상세</h2>
       <TuiViewer content={data?.content} />
     </div>

--- a/client/src/components/project/ProjectInfo.tsx
+++ b/client/src/components/project/ProjectInfo.tsx
@@ -3,7 +3,7 @@ import { arrowRight } from '@/assets/common';
 import { emptyHeart, heart, share } from '@/assets/like';
 import { useState } from 'react';
 import ShareModal from '../kakaoshare/ShareModal';
-import { useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import useSWR from 'swr';
 import { Project } from '@/common/types/responseTypes';
 import { projectApi } from '@/common/api/api';
@@ -18,6 +18,7 @@ export type ModalData = {
 
 function ProjectInfo() {
   const [modalOpen, setModalOpen] = useState(false);
+  const navigate = useNavigate();
   const { projectId } = useParams();
   const { data: projectDetail, isLoading } = useSWR<Project>(
     `/projects/${projectId}`,
@@ -73,7 +74,11 @@ function ProjectInfo() {
             <SquareButton text='396' imgSrc={heart} />
             <SquareButton onClick={() => setModalOpen(true)} text='공유' imgSrc={share} />
           </div>
-          <Button text='펀딩하기' style='w-[70%] text-xl' />
+          <Button
+            text='펀딩하기'
+            style='w-[70%] text-xl'
+            onClick={() => navigate(`/project/${projectId}/payment`)}
+          />
         </div>
       </div>
     </section>

--- a/client/src/components/project/ProjectInfo.tsx
+++ b/client/src/components/project/ProjectInfo.tsx
@@ -3,12 +3,13 @@ import { arrowRight } from '@/assets/common';
 import { emptyHeart, heart, share } from '@/assets/like';
 import { useState } from 'react';
 import ShareModal from '../kakaoshare/ShareModal';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import useSWR from 'swr';
-import { Project } from '@/common/types/responseTypes';
+import { ProjectDetail } from '@/common/types/responseTypes';
 import { projectApi } from '@/common/api/api';
 import { handleImageError } from '@/common/utils';
 import { calculateAchievementRate } from '@/common/utils';
+import { CATEGORY_NUMBER_TO_KO, CategoryNumber } from '@/common/constants/sort';
 
 export type ModalData = {
   title: string;
@@ -20,14 +21,14 @@ function ProjectInfo() {
   const [modalOpen, setModalOpen] = useState(false);
   const navigate = useNavigate();
   const { projectId } = useParams();
-  const { data: projectDetail, isLoading } = useSWR<Project>(
+  const { data: projectDetail, isLoading } = useSWR<ProjectDetail>(
     `/projects/${projectId}`,
     projectApi.getProject
   );
 
   if (isLoading) return <div>Loading...</div>;
 
-  const { imageUrl, summary, title, currentAmount, targetAmount } = projectDetail!;
+  const { imageUrl, summary, title, currentAmount, targetAmount, categoryId = 11 } = projectDetail!;
 
   const modalData: ModalData = {
     title: '프로젝트 제목',
@@ -49,7 +50,9 @@ function ProjectInfo() {
       />
       <div className='flex flex-col w-[42%] justify-between'>
         <div className='flex items-center gap-5pxr'>
-          <span className='text-gray-500 mr-5pxr'>뷰티</span>
+          <span className='text-gray-500 mr-5pxr'>
+            {CATEGORY_NUMBER_TO_KO[categoryId as CategoryNumber]}
+          </span>
           <img src={arrowRight} className='h-12pxr mr-5pxr' alt='' />
           {/* todo: 태그 기능 구현시 추가 */}
           {/* <Patch type='tag'># 남성 화장품</Patch>

--- a/client/src/pages/ProjectPage.tsx
+++ b/client/src/pages/ProjectPage.tsx
@@ -1,5 +1,5 @@
 import { ProjectInfo, ProjectDetail } from '@/components/project';
-import { RewardList } from '@/components/reward';
+// import { RewardList } from '@/components/reward';
 
 function ProjectPage() {
   return (
@@ -7,7 +7,7 @@ function ProjectPage() {
       <ProjectInfo />
       <section className='flex justify-between my-40pxr'>
         <ProjectDetail />
-        <RewardList />
+        {/* <RewardList /> */}
       </section>
     </main>
   );

--- a/client/src/pages/WritePage.tsx
+++ b/client/src/pages/WritePage.tsx
@@ -9,7 +9,7 @@ import { options } from '@/common/constants/sort';
 import { customStyles, style } from '@/components/writepage/styles';
 import { TagType } from '@/components/writepage/TagInput';
 import { projectApi } from '@/common/api/api';
-import { imageCompressor, dday, combineClassNames } from '@/common/utils';
+import { imageCompressor, dday, combineClassNames, dateToString } from '@/common/utils';
 import { ReactComponent as Spinner } from '@/assets/common/spinner.svg';
 import { useNavigate } from 'react-router-dom';
 
@@ -123,8 +123,8 @@ function WritePage() {
             type='text'
             {...register('title', {
               required: '❗️ 필수 항목입니다. 최소 2자, 최대 20자까지 입력 가능합니다.',
-              minLength: 2,
-              maxLength: 50,
+              minLength: { value: 2, message: '❗️ 최소 2자 이상 입력해야 합니다.' },
+              maxLength: { value: 50, message: '❗️ 최대 50자 까지 입력할 수 있습니다.' },
             })}
             className={combineClassNames(style.input, 'w-[80%] mb-30pxr')}
           />
@@ -144,8 +144,8 @@ function WritePage() {
             {...register('targetAmount', {
               required: '❗️ 필수 항목입니다. 최소 5만원부터 최대 천만원까지 입력 가능합니다.',
               valueAsNumber: true,
-              min: 50000,
-              max: 10000000,
+              min: { value: 50000, message: '❗️ 최소 5만원 부터 입력 가능합니다.' },
+              max: { value: 10000000, message: '❗️ 최대 천만원 까지 입력 가능합니다.' },
             })}
             className={combineClassNames(style.input, 'w-full mb-30pxr')}
           />
@@ -162,6 +162,7 @@ function WritePage() {
         <div className='relative'>
           <input
             type='date'
+            min={dateToString()}
             {...register('endDay', {
               required: '❗️ 필수 항목입니다.',
               valueAsDate: true,
@@ -191,7 +192,7 @@ function WritePage() {
             placeholder='나만의 프로젝트 이야기를 요약해 주세요.'
             {...register('summary', {
               required: '❗️ 필수 항목입니다. 최대 100자까지 입력 가능합니다.',
-              maxLength: 100,
+              maxLength: { value: 100, message: '❗️ 최대 100자까지 입력 가능합니다.' },
             })}
           ></textarea>
           <p className={style.error}>{errors.summary?.message}</p>


### PR DESCRIPTION
## Issue
#3 
#8 
#11 

## 구현 내용

- 메인페이지 데이터 페칭 및 바인딩
- 상세페이지 데이터 페칭 및 바인딩
- 프로젝트 작성 로직 일부 수정
   - 유효성 검사 에러 메시지 출력
   - 마감일 지정시 오늘 이후의 날짜만 설정 가능 
- 펀딩하기 버튼 클릭시 결제 페이지로 이동
- 상세 페이지에서 리워드 삭제

## 구현 화면
X

## 참고 사항
X