### PR TITLE
[FE] 프로젝트 펀딩 페이지 데이터패칭

### DIFF
--- a/client/src/common/utils/calculateTotalPrice.ts
+++ b/client/src/common/utils/calculateTotalPrice.ts
@@ -1,5 +1,4 @@
-export const calculateTotalPrice = (quantity: number): number => {
-  const unitPrice = 39500; // Unit price per item
+export const calculateTotalPrice = (quantity: number, unitPrice: number): number => {
   const totalAmount: number = unitPrice * quantity;
   return totalAmount;
 };

--- a/client/src/components/payment/PaymentInfo.tsx
+++ b/client/src/components/payment/PaymentInfo.tsx
@@ -2,6 +2,9 @@ import { useState } from 'react';
 import { DaumPostcodeButton } from '../usermodal';
 import { calculateTotalPrice } from '@/common/utils/calculateTotalPrice';
 import { paymentEqual, paymentMinus } from '@/assets/payment';
+import useSWR from 'swr';
+import { projectApi } from '@/common/api/api';
+import { useParams } from 'react-router-dom';
 
 interface PostcodeData {
   zonecode: string;
@@ -13,6 +16,9 @@ interface PaymentInfoProps {
 }
 
 function PaymentInfo({ quantity }: PaymentInfoProps) {
+  const { projectId } = useParams();
+  const { data } = useSWR(`/projects/${projectId}`, projectApi.getProject);
+  const unitPrice = data?.price;
   const [newAddress, setNewAddress] = useState<string>('');
   const currentBalance = 2902000;
   const [showModal, setShowModal] = useState(false);
@@ -37,7 +43,7 @@ function PaymentInfo({ quantity }: PaymentInfoProps) {
     setShowModal(false);
   };
 
-  const totalProductPrice: number = calculateTotalPrice(quantity);
+  const totalProductPrice: number = calculateTotalPrice(quantity, unitPrice);
   const remainingBalance: number = currentBalance - totalProductPrice;
 
   return (
@@ -68,7 +74,7 @@ function PaymentInfo({ quantity }: PaymentInfoProps) {
           <p className='flex-center'>총 상품가격</p>
           <div className='flex flex-row'>
             <p className='text-2xl italic font-bold flex-center'>
-              {calculateTotalPrice(quantity).toLocaleString()}
+              {calculateTotalPrice(quantity, unitPrice).toLocaleString()}
             </p>
             <p className='flex items-end ml-10pxr'>원</p>
           </div>

--- a/client/src/components/payment/PaymentReward.tsx
+++ b/client/src/components/payment/PaymentReward.tsx
@@ -1,5 +1,8 @@
 import { truck } from '@/assets/payment';
 import { calculateTotalPrice } from '@/common/utils/calculateTotalPrice';
+import useSWR from 'swr';
+import { projectApi } from '@/common/api/api';
+import { useParams } from 'react-router-dom';
 
 interface PaymentRewardProps {
   quantity: number;
@@ -7,30 +10,32 @@ interface PaymentRewardProps {
 }
 
 function PaymentReward({ quantity, handleQuantityChange }: PaymentRewardProps) {
+  const { projectId } = useParams();
+  const { data, isLoading } = useSWR(`/projects/${projectId}`, projectApi.getProject);
+  const expiredDate = new Date(data?.expiredDate);
+  const unitPrice = data?.price;
+
+  if (isLoading) return <div>Loading....</div>;
+
   return (
     <>
       <div className='flex flex-col w-full text-gray-900'>
-        <h1 className='text-3xl font-bold text-black mb-40pxr'>리워드</h1>
+        <h1 className='text-3xl font-bold text-black mb-40pxr'>결제하기</h1>
         <div className='bg-gray-200 h-1pxr mb-25pxr'></div>
         <div className='w-800pxr'>
           <p className='mb-25pxr'>
-            <span className='text-xl italic font-extrabold'>39,500</span> 원
+            <span className='text-xl italic font-extrabold'>{data?.price}</span> 원
           </p>
-          <p className='text-2xl font-bold mb-25pxr'>
-            [울트라 얼리버드] 체험하기 세트 | 영양 크림 1개 + 수분 크림 1개
-          </p>
-          <p className='text-gray-800 mb-25pxr'>
-            최대 2500W 고출력으로 전기포트, 드라이기도 쌉가능! 65W C타입 초고속 충전도 가능한 지코
-            여행어댑터! 해외여행갈때 이제 간편하게 지코 여행어댑터 하나만 챙겨가세요!
-          </p>
+          <p className='text-2xl font-bold mb-25pxr'>{data?.title}</p>
+          <p className='text-gray-800 mb-25pxr'>{data?.summary}</p>
           <div className='flex flex-row mb-25pxr'>
             <img src={truck} alt='truck'></img>
-            <p className='ml-10pxr'>무료 배송 | 리워드 종료일( 07 / 02 )발송 예정</p>
+            <p className='ml-10pxr'>
+              무료 배송 | 리워드 종료일( {expiredDate.toLocaleString('ko-KR')} ) 발송 예정
+            </p>
           </div>
           <div className='bg-gray-100 rounded-lg p-20pxr'>
-            <p className='mb-20pxr'>
-              [울트라 얼리버드] 체험하기 세트 | 영양 크림 1개 + 수분 크림 1개
-            </p>
+            <p className='mb-20pxr'>{data?.title}</p>
             <div className='flex flex-row justify-between'>
               <div className='flex items-center overflow-hidden bg-white border border-solid rounded-md'>
                 <button
@@ -51,7 +56,7 @@ function PaymentReward({ quantity, handleQuantityChange }: PaymentRewardProps) {
               <div>
                 <p className='flex justify-end text-xs text-purple-300'>최종 결제 금액</p>
                 <p className='text-4xl italic font-extrabold text-purple-300'>
-                  {calculateTotalPrice(quantity).toLocaleString()}원
+                  {calculateTotalPrice(quantity, unitPrice).toLocaleString()}원
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Issue
#14 

## 구현 내용

- 상세페이지의 내용을 그대로 가져와서 데이터 패칭
- 결제를 누르면 결제가 완료 되었다는 모달창이 나옴
- 우편번호 검색을 통하여 주소 설정이 가능함

## 구현 화면
X

## 참고 사항
- 유저의 포인트를 가져와야 함(아직 미구현)
- 로그인 상태가 아닐 시 결제 페이지로 오지 못하게 하는 로직이 필요함 (isLogin 사용)