### PR TITLE
[FE] 프로젝트 수정 / 삭제 및 에디터 수정 등

### DIFF
--- a/client/src/common/api/api.ts
+++ b/client/src/common/api/api.ts
@@ -20,4 +20,6 @@ export const projectApi = {
   getProjects: (url: string) => authInstance.get(url).then(({ data }) => data),
   getProject: (url: string) => authInstance.get(url).then(({ data }) => data),
   addProject: <T>(project: T) => authInstance.post('/projects', project),
+  editProject: <T>(id: string, project: T) => authInstance.patch(`/projects/${id}`, project),
+  deleteProject: (id: string) => authInstance.delete(`/projects/${id}`),
 };

--- a/client/src/components/project/ProjectInfo.tsx
+++ b/client/src/components/project/ProjectInfo.tsx
@@ -4,7 +4,7 @@ import { emptyHeart, heart, share } from '@/assets/like';
 import { useState } from 'react';
 import ShareModal from '../kakaoshare/ShareModal';
 import { useNavigate, useParams } from 'react-router-dom';
-import useSWR from 'swr';
+import useSWR, { mutate } from 'swr';
 import { ProjectDetail } from '@/common/types/responseTypes';
 import { projectApi } from '@/common/api/api';
 import { handleImageError } from '@/common/utils';
@@ -28,7 +28,17 @@ function ProjectInfo() {
 
   if (isLoading) return <div>Loading...</div>;
 
-  const { imageUrl, summary, title, currentAmount, targetAmount, categoryId = 11 } = projectDetail!;
+  const {
+    imageUrl,
+    summary,
+    title,
+    currentAmount,
+    targetAmount,
+    memberId,
+    categoryId = 11,
+  } = projectDetail!;
+  const userId = localStorage.getItem('memberId') ?? '비로그인 유저';
+  const isWriter = userId === String(memberId);
 
   const modalData: ModalData = {
     title: '프로젝트 제목',
@@ -40,6 +50,24 @@ function ProjectInfo() {
     setModalOpen(false);
   };
 
+  const deleteProject = async () => {
+    const deleteConfirm = confirm('게시글을 삭제하시겠습니까?');
+    if (deleteConfirm) {
+      try {
+        await projectApi.deleteProject(projectId ?? '');
+        mutate('/projects');
+        alert('게시글 삭제가 완료되었습니다.');
+        navigate('/');
+      } catch (err) {
+        console.log(err);
+      }
+    }
+  };
+
+  const editProject = () => {
+    navigate('/project/edit', { state: projectDetail });
+  };
+
   return (
     <section className='flex justify-between h-410pxr'>
       <img
@@ -49,14 +77,26 @@ function ProjectInfo() {
         onError={handleImageError}
       />
       <div className='flex flex-col w-[42%] justify-between'>
-        <div className='flex items-center gap-5pxr'>
-          <span className='text-gray-500 mr-5pxr'>
-            {CATEGORY_NUMBER_TO_KO[categoryId as CategoryNumber]}
-          </span>
-          <img src={arrowRight} className='h-12pxr mr-5pxr' alt='' />
-          {/* todo: 태그 기능 구현시 추가 */}
-          {/* <Patch type='tag'># 남성 화장품</Patch>
-          <Patch type='tag'># 케어</Patch> */}
+        <div className='flex items-center justify-between'>
+          <div className='flex items-center gap-5pxr'>
+            <span className='text-gray-500 mr-5pxr'>
+              {CATEGORY_NUMBER_TO_KO[categoryId as CategoryNumber]}
+            </span>
+            <img src={arrowRight} className='h-12pxr mr-5pxr' alt='' />
+            {/* todo: 태그 기능 구현시 추가 */}
+            {/* <Patch type='tag'># 남성 화장품</Patch>
+            <Patch type='tag'># 케어</Patch> */}
+          </div>
+          {isWriter && (
+            <div className='flex gap-12pxr'>
+              <button className='text-gray-500' onClick={editProject}>
+                수정
+              </button>
+              <button className='text-gray-500' onClick={deleteProject}>
+                삭제
+              </button>
+            </div>
+          )}
         </div>
         <h1 className='text-2xl font-semibold'>{title}</h1>
         <p className='text-sm text-gray-800'>{summary}</p>

--- a/client/src/components/project/ProjectItem.tsx
+++ b/client/src/components/project/ProjectItem.tsx
@@ -12,7 +12,7 @@ function ProjectItem({ project }: Props) {
   const isDueSoon = daysUntilDeadline <= 7;
 
   return (
-    <article className='relative flex flex-col cursor-pointer w-400pxr'>
+    <article className='relative flex flex-col cursor-pointer w-400pxr mb-35pxr'>
       {isDueSoon && <Patch type='alert'>마감임박</Patch>}
       <img
         src={imageUrl}

--- a/client/src/components/writepage/TagInput.tsx
+++ b/client/src/components/writepage/TagInput.tsx
@@ -13,7 +13,7 @@ type Props = {
   getTags: (tags: TagType[]) => void;
 };
 
-const MAX_TAGS = 10;
+const MAX_TAGS = 5;
 const TAG_MAX_LEN = 10;
 
 function TagInput({ initialTags = [], style, tagRef, getTags }: Props) {
@@ -70,7 +70,9 @@ function TagInput({ initialTags = [], style, tagRef, getTags }: Props) {
           onKeyUp={setTagsByKey}
         />
       </div>
-      <div className='text-sm text-purple-300 ml-12pxr mb-30pxr'>{tags.length} / 10 개의 태그</div>
+      <div className='text-sm text-purple-300 ml-12pxr mb-30pxr'>
+        {tags.length} / {MAX_TAGS} 개의 태그
+      </div>
       <button className='hidden' type='button' onClick={() => getTags(tags)} ref={tagRef}></button>
     </>
   );

--- a/client/src/components/writepage/styles.ts
+++ b/client/src/components/writepage/styles.ts
@@ -6,7 +6,7 @@ export const style = {
   subTitle: 'text-2xl font-bold text-gray-900 my-10pxr',
   input: 'border border-solid rounded border-gray-400 py-5pxr px-10pxr focus:border-purple-300',
   fileInput:
-    'border-b border-solid border-gray-400 w-[80%] py-5pxr mb-30pxr text-sm text-gray-900 focus:border-purple-300 file:py-3pxr file:px-15pxr file:rounded-full file:border-0 file:bg-purple-300 file:text-white file:mr-10pxr',
+    'border-b border-solid border-gray-400 w-[30%] py-5pxr mb-30pxr text-sm text-gray-900 focus:border-purple-300 file:py-3pxr file:px-15pxr file:rounded-full file:border-0 file:bg-purple-300 file:text-white file:mr-10pxr',
   tagInput: 'w-[80%] flex items-center overflow-hidden mb-10pxr',
   textarea: 'w-[80%] mb-25pxr outline-none h-150pxr',
   submitButton:

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -43,3 +43,8 @@ input::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
+
+.toastui-editor-contents p,
+.toastui-editor-contents h6 {
+  font-size: 1rem !important;
+}

--- a/client/src/pages/WritePage.tsx
+++ b/client/src/pages/WritePage.tsx
@@ -147,12 +147,15 @@ function WritePage() {
           <p className={style.error}>{errors.title?.message}</p>
         </div>
         <h3 className={style.subTitle}>대표 이미지</h3>
-        <input
-          type='file'
-          accept='.png, .jpg, .jpeg'
-          className={style.fileInput}
-          onChange={getThumbnailUrl}
-        />
+        <div className='flex gap-15pxr'>
+          <input
+            type='file'
+            accept='.png, .jpg, .jpeg'
+            className={style.fileInput}
+            onChange={getThumbnailUrl}
+          />
+          {isEditPage && <p className={style.info}>※ 미첨부시 기존 이미지가 유지됩니다.</p>}
+        </div>
         <h3 className={style.subTitle}>상품 가격</h3>
         <div className='relative w-[80%]'>
           <input

--- a/client/src/pages/WritePage.tsx
+++ b/client/src/pages/WritePage.tsx
@@ -11,7 +11,7 @@ import { TagType } from '@/components/writepage/TagInput';
 import { projectApi } from '@/common/api/api';
 import { imageCompressor, dday, combineClassNames, dateToString } from '@/common/utils';
 import { ReactComponent as Spinner } from '@/assets/common/spinner.svg';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import KakaoMap from '@/components/kakaomap/KakaoMap';
 
 type Category = {
@@ -28,6 +28,7 @@ type FormData = {
   imageUrl: string;
   summary: string;
   content: string;
+  price: number;
   tags?: string[];
   location?: string;
 };
@@ -43,12 +44,17 @@ function WritePage() {
   const imageRef = useRef('');
   const locationRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
+  const location = useLocation();
+  const initialState = location.state ?? {};
+  const isEditPage = location.pathname.includes('edit');
 
   const {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<FormData>();
+  } = useForm<FormData>({
+    defaultValues: { ...initialState, endDay: dateToString(new Date(initialState.expiredDate)) },
+  });
 
   const hasContent = (str: string) => {
     return !!str.replace(/<br>/g, '').trim().length;
@@ -70,12 +76,17 @@ function WritePage() {
     data.content = editorRef.current?.getInstance().getHTML();
     data.imageUrl = imageRef.current;
     data.categoryId = selectRef.current.value;
-    data.location = locationRef.current?.value;
+    // data.location = locationRef.current?.value;
     // data.tags = tagRef.current;
     console.log(data);
     try {
-      await projectApi.addProject<FormData>(data);
-      navigate('/');
+      if (isEditPage) {
+        await projectApi.editProject<FormData>(initialState.projectId, data);
+        navigate(`/project/${initialState.projectId}`);
+      } else {
+        await projectApi.addProject<FormData>(data);
+        navigate('/');
+      }
     } catch (err) {
       console.log(err);
     } finally {
@@ -142,6 +153,20 @@ function WritePage() {
           className={style.fileInput}
           onChange={getThumbnailUrl}
         />
+        <h3 className={style.subTitle}>상품 가격</h3>
+        <div className='relative w-[80%]'>
+          <input
+            type='number'
+            {...register('price', {
+              required: '❗️ 필수 항목입니다.',
+              valueAsNumber: true,
+              max: { value: 10000000, message: '❗️ 최대 천만원 까지 입력 가능합니다.' },
+            })}
+            className={combineClassNames(style.input, 'w-full mb-30pxr')}
+          />
+          <span className='absolute top-[10%] right-15pxr'>원</span>
+          <p className={style.error}>{errors.price?.message}</p>
+        </div>
         <h3 className={style.subTitle}>목표 금액</h3>
         <div className='relative w-[80%]'>
           <input
@@ -185,6 +210,7 @@ function WritePage() {
             placeholder='카테고리 선택'
             components={{ IndicatorSeparator: null }}
             onChange={onSelect}
+            defaultValue={options.find((option) => option.value === initialState.categoryId)}
           />
           <p className={style.info}>※ 카테고리 미선택시 '기타'로 분류됩니다.</p>
         </div>
@@ -212,7 +238,11 @@ function WritePage() {
         </div>
         <h3 className={style.subTitle}>프로젝트 스토리</h3>
         <div className={style.editor}>
-          <TuiEditor editorRef={editorRef} imageHandler={handleImage} />
+          <TuiEditor
+            editorRef={editorRef}
+            imageHandler={handleImage}
+            content={initialState.content}
+          />
         </div>
         {emptyError && (
           <p className={style.empty}>❗️필수 항목입니다. 내용 혹은 이미지가 포함되어야 합니다.</p>
@@ -223,7 +253,7 @@ function WritePage() {
           className={style.submitButton}
           onClick={handleSubmit(onSubmit)}
         >
-          {isLoading ? <Spinner /> : '프로젝트 생성'}
+          {isLoading ? <Spinner /> : isEditPage ? '프로젝트 수정' : '프로젝트 생성'}
         </button>
       </form>
       <ScrollUpButton />


### PR DESCRIPTION
## Issue
#13
#15 

## 구현 내용

- 작성자의 경우 프로젝트 상세 화면에 수정 / 삭제 버튼 노출
- 수정 버튼 클릭시 작성 페이지로 이동하며, 게시글 정보가 기본값으로 설정됨
- 수정 완료시 게시글 상세 페이지로 이동
- 삭제 버튼 클릭시 삭제 확인 얼럿이 노출되며, 확인시 삭제 로직 수행 후 메인페이지로 이동
- 토스트 에디터 폰트 크기 수정 (14px -> 1rem)

## 구현 화면
<img width="1440" alt="스크린샷 2023-07-21 오전 11 05 45" src="https://github.com/codestates-seb/seb44_main_036/assets/107546528/15b7396f-b626-47cb-a634-3a52725ac5bd">

## 참고 사항
X