### PR TITLE
[FE] 정렬, api, responseType 수정, 태그 추가

### DIFF
--- a/client/src/common/types/responseTypes.ts
+++ b/client/src/common/types/responseTypes.ts
@@ -15,6 +15,7 @@ export type Project = {
   likedProject: number;
   location: string | null;
   view: number;
+  tags: string[];
 };
 
 export type Projects = Project[];

--- a/client/src/components/project/ProjectDetail.tsx
+++ b/client/src/components/project/ProjectDetail.tsx
@@ -2,10 +2,19 @@ import { useParams } from 'react-router-dom';
 import { TuiViewer } from '../editor';
 import useSWR from 'swr';
 import { projectApi } from '@/common/api/api';
+import { useCallback } from 'react';
+import { useAppSelector } from '@/hooks/useReducer';
 
 function ProjectDetail() {
   const { projectId } = useParams();
-  const { data, isLoading } = useSWR(`/projects/${projectId}`, projectApi.getProject);
+  const userData = useAppSelector((state) => state.user.data);
+
+  const getProjectEndpoint = useCallback(() => {
+    if (userData) return `/projects/${projectId}/${userData.memberId}`;
+    else return `/projects/${projectId}`;
+  }, [userData, projectId]);
+
+  const { data, isLoading } = useSWR(getProjectEndpoint(), projectApi.getProject);
 
   if (isLoading) return <div>Loading....</div>;
 

--- a/client/src/components/project/ProjectItem.tsx
+++ b/client/src/components/project/ProjectItem.tsx
@@ -4,16 +4,17 @@ import { Patch, Like } from '../ui';
 import { dday, formattingNumber, calculateAchievementRate, handleImageError } from '@/common/utils';
 import { mutate } from 'swr';
 import { useAppSelector } from '@/hooks/useReducer';
-import { redirect, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 export type LikeHandler = (e: React.MouseEvent<HTMLImageElement, MouseEvent>) => void;
 
 type Props = {
   project: Project;
   projects: Projects;
+  endpoint?: string;
 };
 
-function ProjectItem({ project, projects }: Props) {
+function ProjectItem({ project, projects, endpoint }: Props) {
   const {
     currentAmount,
     expiredDate,
@@ -28,7 +29,6 @@ function ProjectItem({ project, projects }: Props) {
   const isDueSoon = daysUntilDeadline <= 7;
   const userData = useAppSelector((state) => state.user.data);
   const navigate = useNavigate();
-  const { categoryId } = useParams();
 
   const handleHeartClick: LikeHandler = async (e) => {
     e.preventDefault();
@@ -51,7 +51,7 @@ function ProjectItem({ project, projects }: Props) {
         likeCount: updatedLikeCount,
       };
       mutate(
-        `/projects${categoryId ? `/category/${categoryId}` : ''}`,
+        endpoint,
         projects.map((project) => (project.projectId === projectId ? updatedProject : project)),
         false
       );


### PR DESCRIPTION
## Issue
X

## 구현 내용

- 메인페이지 '인기순' 정렬 기준을 좋아요 개수에서 조회수로 변경
- 로그인/비로그인에 상태에 따라 메인페이지/상세페이지 데이터 get 엔드포인트 분리
- 상세페이지 태그 추가
- 태그 기능 구현으로 responseType 수정

## 구현 화면
X

## 참고 사항
로그인 상태에서 카테고리별 get 불가 (서버 구현 후 수정 예정)